### PR TITLE
Add endpoint for grouped historic counts of actions

### DIFF
--- a/API.md
+++ b/API.md
@@ -82,3 +82,35 @@ The API address lies here: `http://54.147.184.23:8000/`.
     }]
 }
 ```
+
+### GET `/count_history/{task}/{action}/{grouping}`
+- returns the count history of a defined {action}, grouped by {grouping}
+- {action} corresponds to previously tracked actions with /track
+- {grouping} can be any field from [PostgreSQL's date_trunc](http://www.postgresql.org/docs/9.1/static/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC)
+    - ex: hour, day, week, month
+- request example: `/count_history/unconnectedmajor/fix/day`
+- response example:
+```js
+{
+    "updated": 1427303352,
+    "data": [{
+        "count": 41,
+        "start": 1427155200
+    }, {
+        "count": 1527,
+        "start": 1427068800
+    }, {
+        "count": 58,
+        "start": 1426896000
+    }, {
+        "count": 3,
+        "start": 1426982400
+    }, {
+        "count": 589,
+        "start": 1426809600
+    }, {
+        "count": 7,
+        "start": 1427241600
+    }]
+}
+```

--- a/index.js
+++ b/index.js
@@ -111,6 +111,30 @@ server.route({
 
 server.route({
     method: 'GET',
+    path: '/count_history/{task}/{grouping}',
+    handler: function(request, reply) {
+        // grouping = daily,hourly,minutely
+
+        var table = request.params.task.replace(/[^a-zA-Z]+/g, '').toLowerCase();
+        var query = "select count(*), date_trunc($1, to_timestamp(time)) as group from " + table + "_stats group by date_trunc($1, to_timestamp(time));";
+        client.query(query, [request.params.grouping], function(err, results) {
+            if (err) return reply(boom.badRequest(err));
+            if (results.rowCount > 0) {
+                var out = [];
+                results.rows.forEach(function(row) {
+                    out.push({
+                        start: Math.round(+new Date(row.group)/1000),
+                        count: parseInt(row.count)
+                    });
+                });
+                reply(out);
+            }
+        });
+    }
+});
+
+server.route({
+    method: 'GET',
     path: '/track/{task}/{key}:{value}/{to?}',
     handler: function(request, reply) {
         // gets results filtered by key:value or by date range

--- a/index.js
+++ b/index.js
@@ -119,16 +119,15 @@ server.route({
         var query = "select count(*), date_trunc($1, to_timestamp(time)) as group from " + table + "_stats group by date_trunc($1, to_timestamp(time));";
         client.query(query, [request.params.grouping], function(err, results) {
             if (err) return reply(boom.badRequest(err));
-            if (results.rowCount > 0) {
-                var out = [];
-                results.rows.forEach(function(row) {
-                    out.push({
-                        start: Math.round(+new Date(row.group)/1000),
-                        count: parseInt(row.count)
-                    });
-                });
-                reply(out);
-            }
+            reply({
+                updated: Math.round(+new Date()/1000),
+                data: results.rows.map(function(row) {
+                    return {
+                        count: parseInt(row.count),
+                        start: Math.round(+new Date(row.group)/1000)
+                    };
+                })
+            });
         });
     }
 });

--- a/index.js
+++ b/index.js
@@ -111,11 +111,11 @@ server.route({
 
 server.route({
     method: 'GET',
-    path: '/count_history/{task}/{grouping}',
+    path: '/count_history/{task}/{action}/{grouping}',
     handler: function(request, reply) {
         var table = request.params.task.replace(/[^a-zA-Z]+/g, '').toLowerCase();
-        var query = "select count(*), date_trunc($1, to_timestamp(time)) as group from " + table + "_stats group by date_trunc($1, to_timestamp(time));";
-        client.query(query, [request.params.grouping], function(err, results) {
+        var query = "select count(*), date_trunc($1, to_timestamp(time)) as group from " + table + "_stats where attributes->'action'=$2 group by date_trunc($1, to_timestamp(time)), attributes->'action'=$2;";
+        client.query(query, [request.params.grouping, request.params.action], function(err, results) {
             if (err) return reply(boom.badRequest(err));
             reply({
                 updated: Math.round(+new Date()/1000),

--- a/index.js
+++ b/index.js
@@ -113,8 +113,6 @@ server.route({
     method: 'GET',
     path: '/count_history/{task}/{grouping}',
     handler: function(request, reply) {
-        // grouping = daily,hourly,minutely
-
         var table = request.params.task.replace(/[^a-zA-Z]+/g, '').toLowerCase();
         var query = "select count(*), date_trunc($1, to_timestamp(time)) as group from " + table + "_stats group by date_trunc($1, to_timestamp(time));";
         client.query(query, [request.params.grouping], function(err, results) {


### PR DESCRIPTION
Addresses #10 
- `/count` will return the current count of items for a given task
- `/count_history` will return the historic count of items, grouped by a specified time period (hour, day, month, etc..)
