### PR TITLE
Allow importing errors for existing tasks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# System files
+.project
+.DS_Store
+.sass-cache
+node_modules
+.tmp
+
+# Local
+.resources


### PR DESCRIPTION
We've been using to-fix for a project and noticed that there was no way to add errors to existing tasks.
This modifies the `/csv` endpoint to accept errors for existing tasks. When a csv is posted if the tables already exist the data will be appended.
The task table now has a PRIMARY KEY so there's some degree of validation.

Let me know what you think.
