### PR TITLE
[wip] return status OK only when db connection is successful

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -21,15 +21,13 @@ server.use(bodyParser.json());
 
 // TODO: Write docs using https://github.com/tmcw/docbox
 
-server.get('/', function(req, res) {
+server.get('/', function(req, res, next) {
   db
     .authenticate()
     .then(() => {
       res.json({ status: 'OK' });
     })
-    .catch(() => {
-      res.json({ status: 'NOT OK' });
-    });
+    .catch(err => next(err));
 });
 
 server.get('/tasks', function(req, res, next) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -22,8 +22,14 @@ server.use(bodyParser.json());
 // TODO: Write docs using https://github.com/tmcw/docbox
 
 server.get('/', function(req, res) {
-  // TODO: check that the database is up and running so the status will be valid
-  res.json({ status: 'OK' });
+  db
+    .authenticate()
+    .then(() => {
+      res.json({ status: 'OK' });
+    })
+    .catch(() => {
+      res.json({ status: 'NOT OK' });
+    });
 });
 
 server.get('/tasks', function(req, res, next) {

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -1,0 +1,13 @@
+const test = require('./lib/test');
+
+test('GET / - check that status is OK when db connection works', [], function(
+  assert
+) {
+  assert.app.get('/').expect(200, function(err, res) {
+    if (err) return assert.end(err);
+    assert.equal(res.body.status, 'OK', 'status returns OK');
+    assert.end();
+  });
+});
+
+//TODO: Figure out how to write test for when db connection fails


### PR DESCRIPTION
Refs https://github.com/osmlab/to-fix-backend/pull/113

Questions:

 - What status code should we return on failure?
 - @mcwhittemore could you help me out with the failing test? i.e. mocking the db connection not working and testing that the `/` status end-point correctly returns `NOT OK` (or whatever we want it to return) -- wasn't sure how to cleanly over-ride the db setup stuff in `lib/test.js`

cc @kepta 