### PR TITLE
breaking test: tofix gives up when putting items

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node index.js",
     "precommit": "lint-staged",
-    "test": "npm run lint && NODE_ENV=test tape test/*.test.js | tap-colorize",
+    "test": "npm run lint && NODE_ENV=test tape test/*.test.js",
     "lint": "eslint .",
     "format": "prettier --single-quote --write \"{,test/**/}*.{js,json}\"",
     "api-docs":

--- a/test/task-items-put.test.js
+++ b/test/task-items-put.test.js
@@ -132,6 +132,63 @@ test(
 );
 
 test(
+  'PUT /tasks/:id/items:id - should create a valid item without errors',
+  taskWithNoItems,
+  function(assert) {
+    const featureCollection = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: { type: 'node' },
+          geometry: {
+            type: 'Point',
+            coordinates: [30, 30]
+          }
+        }
+      ]
+    };
+    assert.app
+      .put('/tasks/one/items/good-item')
+      .send({
+        pin: [30, 30],
+        instructions: 'test',
+        featureCollection
+      })
+      .expect(200, function(err, res) {
+        if (err) return assert.end(err);
+        var item = removeDates(res.body);
+        assert.deepEqual(
+          {
+            status: 'open',
+            id: 'good-item',
+            task_id: 'one',
+            pin: { type: 'Point', coordinates: [30, 30] },
+            instructions: 'test',
+            featureCollection: {
+              type: 'FeatureCollection',
+              features: [
+                {
+                  type: 'Feature',
+                  properties: { type: 'node' },
+                  geometry: {
+                    type: 'Point',
+                    coordinates: [30, 30]
+                  }
+                }
+              ]
+            },
+            createdBy: 'userone',
+            lockedBy: null
+          },
+          item
+        );
+        assert.end();
+      });
+  }
+);
+
+test(
   'PUT /tasks/:id/items:id - updating an item with an invalid feature collection errors',
   taskWithOneUnlockedItem,
   function(assert) {
@@ -360,3 +417,11 @@ test(
       });
   }
 );
+
+// test('PUT /tasks/:id/items/:id - bulk upload items', taskWithNoItems, function(
+//   assert
+// ) {
+//   const TOTAL_REQUESTS = 2000;
+//   const requests = [];
+//   for (let i = 0; i < TOTAL_REQUESTS; i++) {}
+// });

--- a/test/task-items-put.test.js
+++ b/test/task-items-put.test.js
@@ -467,7 +467,7 @@ test(
   'PUT /tasks/:id/items/:id - bulk upload items without waiting',
   taskWithNoItems,
   function(assert) {
-    const TOTAL_REQUESTS = 10;
+    const TOTAL_REQUESTS = 1000;
     const requests = [];
     const featureCollection = {
       type: 'FeatureCollection',

--- a/test/task-items-put.test.js
+++ b/test/task-items-put.test.js
@@ -462,3 +462,44 @@ test(
       });
   }
 );
+
+test(
+  'PUT /tasks/:id/items/:id - bulk upload items without waiting',
+  taskWithNoItems,
+  function(assert) {
+    const TOTAL_REQUESTS = 10;
+    const requests = [];
+    const featureCollection = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: { type: 'node' },
+          geometry: {
+            type: 'Point',
+            coordinates: [30, 30]
+          }
+        }
+      ]
+    };
+    for (let i = 0; i < TOTAL_REQUESTS; i++) {
+      requests.push(
+        assert.app
+          .put(`/tasks/one/items/item-${i}`)
+          .send({
+            pin: [30, 30],
+            instructions: 'test',
+            featureCollection
+          })
+          .expect(200)
+      );
+    }
+    Promise.all(requests)
+      .then(function() {
+        assert.end();
+      })
+      .catch(function(err) {
+        return assert.end(err);
+      });
+  }
+);


### PR DESCRIPTION
- This adds test to test multiple requests putting item with delay
- This adds test to test multiple requests putting item without delay
- This adds test to test a simple valid item put request
- Failing tests were exiting with status 0, have removed `tape-colour` for now. (_how to pipe and still throw error 1?_)

The test `PUT /tasks/:id/items/:id - bulk upload items without waiting` fails.

ref #129 

cc @mcwhittemore @batpad 