### PR TITLE
Upgrades sequelize

### DIFF
--- a/database/db.js
+++ b/database/db.js
@@ -16,7 +16,8 @@ var db = (module.exports = new Sequelize(database, user, password, {
     max: 5,
     min: 0,
     idle: 10000
-  }
+  },
+  operatorsAliases: false
 }));
 
 var ProjectItems = (module.exports.ProjectItems = require('./project-items')(

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,17 +18,17 @@
       }
     },
     "@types/geojson": {
-      "version": "1.0.3",
+      "version": "1.0.5",
       "resolved":
-        "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.3.tgz",
+        "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.5.tgz",
       "integrity":
-        "sha512-unWrGQhXRrNTk/MabfBLCM/rWT6zxR1OSK0GIPxsP8NX8mJcsNWkERPp4z0pTyHLiANy+Nwczf8Q2I16Pth1FA=="
+        "sha512-Vv/xcob92T/Vncg/AvPMYS0R2a+PYBnnTGNb7bE8jyqEXqq08Tp1frhx6+ExKCImyQq6iLfqjeXt/Wtsh8Sjgw=="
     },
     "@types/node": {
-      "version": "8.0.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.29.tgz",
+      "version": "8.0.44",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.44.tgz",
       "integrity":
-        "sha512-C5h3jl321dtwQJJAl6poPm7YmDneEv1cpRMZxJ7vlH03XN6OQix4LxTHBBZBj/aPVhlO2dO5fbfgdxYkn2ArKw=="
+        "sha512-56TeARKE2uMi7xWhpRRws/QdnpSVx9i7E8esGiPYoj90jnonGfmV1vwRLvHWYjPxF5u5l7p5fgdKwdse+VeAQQ=="
     },
     "accepts": {
       "version": "1.3.4",
@@ -1383,9 +1383,10 @@
         "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
     },
     "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity":
+        "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "body": {
       "version": "5.1.0",
@@ -3945,10 +3946,11 @@
       }
     },
     "generic-pool": {
-      "version": "3.1.8",
+      "version": "3.2.0",
       "resolved":
-        "https://registry.npmjs.org/generic-pool/-/generic-pool-3.1.8.tgz",
-      "integrity": "sha1-CYRLZUW8kXfsIYvTXUrYlMZb4nE="
+        "https://registry.npmjs.org/generic-pool/-/generic-pool-3.2.0.tgz",
+      "integrity":
+        "sha512-JjcXDHT84icN/kFaF5+rNd1trZsgJFVqTSgM9dv6eayxSIQKMq0ilBJ+5pvf0SgimacMlZEsav4oL+4dUE4E2g=="
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -7576,7 +7578,7 @@
         "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-2.3.1.tgz",
       "integrity": "sha1-91BZGD+XMHccCbrR7tV1N5McvJ0=",
       "requires": {
-        "bluebird": "3.5.0",
+        "bluebird": "3.5.1",
         "debug": "2.6.9"
       }
     },
@@ -7662,17 +7664,17 @@
       }
     },
     "sequelize": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-4.10.0.tgz",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-4.15.0.tgz",
       "integrity":
-        "sha512-WD53jhgDQmtx/z1hbr2WB+i1f9oAgi9gXeerC6xwRynAP1Xh8W2KM8JCyZ3PslGX3zc9/w3Ic/m+hp1myBJ0jQ==",
+        "sha512-E0TEw3QZbNCoi6sRUXzOSS/A/OPvrfke8qIinGD9MsQV6HddBv6YnIO3oQc7gGsct7OvI1kPRFRkPuMIKT4rEw==",
       "requires": {
-        "bluebird": "3.5.0",
+        "bluebird": "3.5.1",
         "cls-bluebird": "2.0.1",
-        "debug": "3.0.1",
+        "debug": "3.1.0",
         "depd": "1.1.1",
         "dottie": "2.0.0",
-        "generic-pool": "3.1.8",
+        "generic-pool": "3.2.0",
         "inflection": "1.12.0",
         "lodash": "4.17.4",
         "moment": "2.18.1",
@@ -7681,16 +7683,16 @@
         "semver": "5.4.1",
         "terraformer-wkt-parser": "1.1.2",
         "toposort-class": "1.0.1",
-        "uuid": "3.0.1",
+        "uuid": "3.1.0",
         "validator": "8.2.0",
         "wkx": "0.4.2"
       },
       "dependencies": {
         "debug": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.0.1.tgz",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity":
-            "sha512-6nVc6S36qbt/mutyt+UGMnawAMrPDZUPQjRZI3FS9tCtDRhvxJbK79unYBLPi+z5SLXQ3ftoVBFCblQtNSls8w==",
+            "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -8535,7 +8537,7 @@
         "https://registry.npmjs.org/terraformer/-/terraformer-1.0.8.tgz",
       "integrity": "sha1-UeCtiXRvzyFh3G9lqnDkI3fItZM=",
       "requires": {
-        "@types/geojson": "1.0.3"
+        "@types/geojson": "1.0.5"
       }
     },
     "terraformer-wkt-parser": {
@@ -9107,9 +9109,10 @@
       "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
     },
     "uuid": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity":
+        "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "vali-date": {
       "version": "1.0.0",
@@ -9330,7 +9333,7 @@
       "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.2.tgz",
       "integrity": "sha1-d201pjSlwi5lbkdEvetU+D/Szo0=",
       "requires": {
-        "@types/node": "8.0.29"
+        "@types/node": "8.0.44"
       }
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prettier": "^1.7.0",
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",
-    "sequelize": "^4.10.0",
+    "sequelize": "^4.15.0",
     "xml2json": "^0.11.0"
   },
   "engines": {


### PR DESCRIPTION
Refs https://github.com/osmlab/to-fix-backend/issues/130

This PR upgrades sequelize, which addresses the undefined `Sequelize.Op` object that was causing tests to fail.

~🚩 String-based operators are being deprecated, so we'll want to switch to symbol-based operators.~ This is just a warning. I can't find any examples where we use string-based operators; we've already switched to symbols.

cc @batpad @samanpwbb 