### PR TITLE
TLC

### DIFF
--- a/API.md
+++ b/API.md
@@ -93,7 +93,7 @@ curl https://host/v1/projects/00000000-0000-0000-0000-000000000000/tags
 ]
 ```
 
-### get-item-comments
+### get-comments
 
 Get a list of comments for an item
 
@@ -109,36 +109,80 @@ Get a list of comments for an item
 curl https://host/v1/projects/:project/items/:item/comments
 
 [
-{
-  "id": "e67c585d-d93f-4ea6-a59f-87b8b54e6efd",
-  "createdBy": "usertwo",
-  "body": "first",
-  "coordinates": {
-    "type": "Point",
-    "coordinates": [
-      0,
-      0
-    ]
+  {
+    "id": "e67c585d-d93f-4ea6-a59f-87b8b54e6efd",
+    "createdBy": "usertwo",
+    "body": "first",
+    "coordinates": {
+      "type": "Point",
+      "coordinates": [
+        0,
+        0
+      ]
+    },
+    "metadata": {},
+    "createdAt": "2017-10-20T20:39:06.580Z",
+    "updatedAt": "2017-10-20T20:39:06.580Z"
   },
-  "metadata": {},
-  "createdAt": "2017-10-20T20:39:06.580Z",
-  "updatedAt": "2017-10-20T20:39:06.580Z"
-},
-{
-  "id": "3a47cd22-1761-4582-8cc6-32da1c0bd970",
-  "createdBy": "userone",
-  "body": "second",
-  "coordinates": {
-    "type": "Point",
-    "coordinates": [
-      0,
-      0
-    ]
-  },
-  "metadata": {},
-  "createdAt": "2017-10-20T20:39:06.581Z",
-  "updatedAt": "2017-10-20T20:39:06.581Z"
-}
+  {
+    "id": "3a47cd22-1761-4582-8cc6-32da1c0bd970",
+    "createdBy": "userone",
+    "body": "second",
+    "coordinates": {
+      "type": "Point",
+      "coordinates": [
+        0,
+        0
+      ]
+    },
+    "metadata": {},
+    "createdAt": "2017-10-20T20:39:06.581Z",
+    "updatedAt": "2017-10-20T20:39:06.581Z"
+  }
+]
+```
+
+### get-items
+
+Get a paginated list of items for a project.
+
+**Parameters**
+
+-   `params` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** The request URL parameters
+    -   `params.project` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The project ID
+-   `query` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** The request URL query parameters
+    -   `query.lock` **(`"locked"` \| `"unlocked"`)** The item's lock status, must be 'locked' or 'unlocked' (optional, default `'locked'`)
+    -   `query.page` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The pagination start page (optional, default `0`)
+    -   `query.page_size` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The page size (optional, default `100`)
+    -   `query.bbox` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** BBOX to query by, string in W,S,E,N format (e.g. -1,-1,0,0)
+    -   `query.status` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** Status to filter items by
+
+**Examples**
+
+```javascript
+curl https://host/v1/projects/:project/items
+
+[
+  {
+    status: 'open',
+    lockedTill: '2017-10-19T00:00:00.000Z',
+    metadata: {},
+    id: '405270',
+    project_id: '00000000-0000-0000-0000-000000000000',
+    pin: {
+      type: 'Point',
+      coordinates: [0, 0]
+    },
+    instructions: 'Fix this item',
+    featureCollection: {
+      type: 'FeatureCollection',
+      features: []
+    },
+    createdBy: 'user',
+    updatedAt: '2017-10-19T00:00:00.000Z',
+    createdAt: '2017-10-19T00:00:00.000Z',
+    lockedBy: null
+  }
 ]
 ```
 
@@ -164,51 +208,6 @@ curl -X POST -H "Content-Type: application/json" -d '{"name":"My Project"}' http
   updatedAt: '2017-10-19T00:00:00.000Z',
   createdAt: '2017-10-19T00:00:00.000Z'
 }
-```
-
-### get-project-items
-
-Get a paginated list of items for a project.
-
-**Parameters**
-
--   `params` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** The request URL parameters
-    -   `params.project` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The project ID
--   `query` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** The request URL query parameters
-    -   `query.lock` **(`"locked"` \| `"unlocked"`)** The item's lock status, must be 'locked' or 'unlocked' (optional, default `'locked'`)
-    -   `query.page` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The pagination start page (optional, default `0`)
-    -   `query.page_size` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The page size (optional, default `100`)
-    -   `query.bbox` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** BBOX to query by, string in W,S,E,N format - eg. -1,-1,0,0
-    -   `query.status` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Status to filter items by
-
-**Examples**
-
-```javascript
-curl https://host/v1/projects/:project/items
-
-[
-  {
-    status: 'open',
-    lockedTill: '2017-10-19T00:00:00.000Z',
-    siblings: [],
-    metadata: {},
-    id: '405270',
-    project_id: '00000000-0000-0000-0000-000000000000',
-    pin: {
-      type: 'Point',
-      coordinates: [0, 0]
-    },
-    instructions: 'Fix this item',
-    featureCollection: {
-      type: 'FeatureCollection',
-      features: []
-    },
-    createdBy: 'user',
-    updatedAt: '2017-10-19T00:00:00.000Z',
-    createdAt: '2017-10-19T00:00:00.000Z',
-    lockedBy: null
-  }
-]
 ```
 
 ### create-project-tag
@@ -262,7 +261,7 @@ curl https://host/v1/projects/00000000-0000-0000-0000-000000000000
 }
 ```
 
-### create-item-comment
+### create-comment
 
 Create a comment
 
@@ -272,35 +271,33 @@ Create a comment
     -   `params.project` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The project ID
     -   `params.item` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The item ID
 -   `body` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** The request body
-    -   `body.body` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Body of the comment (required)
-    -   `body.pin` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** coordinates of pin
+    -   `body.body` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Comment body
+    -   `body.pin` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>** Comment coordinates (optional, default `null`)
+    -   `body.metadata` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Comment metadata (optional, default `{}`)
 
 **Examples**
 
 ```javascript
-curl \
--X POST \
--H "Content-Type: application/json" \
--d '{"body":"i like this item","pin":[0,0]}' \
-https://host/v1/projects/00000000-0000-0000-0000-000000000000/items/77
+curl -X POST -H "Content-Type: application/json" -d '{"body":"i like this item","pin":[0,0]}' https://host/v1/projects/00000000-0000-0000-0000-000000000000/items/77
+
 {
-"id": "d0280f1f-c5cc-448d-9b88-5cf9e52f8e18",
-"createdBy": "userone",
-"body": "i like this item",
-"pin": {
-  "type": "Point",
-  "coordinates": [
-    0,
-    0
-  ]
-},
-"metadata": {},
-"createdAt": "2017-10-23T17:18:01.801Z",
-"updatedAt": "2017-10-23T17:18:01.801Z"
+  "id": "d0280f1f-c5cc-448d-9b88-5cf9e52f8e18",
+  "createdBy": "userone",
+  "body": "i like this item",
+  "pin": {
+    "type": "Point",
+    "coordinates": [
+      0,
+      0
+    ]
+  },
+  "metadata": {},
+  "createdAt": "2017-10-23T17:18:01.801Z",
+  "updatedAt": "2017-10-23T17:18:01.801Z"
 }
 ```
 
-### updateProject
+### update-project
 
 Update a project.
 
@@ -309,6 +306,8 @@ Update a project.
 -   `params` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** The request URL parameters
     -   `params.project` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The project ID
 -   `body` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** The request body
+    -   `body.name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** The project name
+    -   `body.metadata` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** The project metadata
 
 **Examples**
 
@@ -367,20 +366,16 @@ Create an item in a project.
     -   `body.lock` **(`"unlocked"` \| `"locked"`)?** The item's lock status
     -   `body.status` **(`"open"` \| `"fixed"` \| `"noterror"`)?** The item's status
     -   `body.featureCollection` **FeatureCollection?** The item's featureCollection context
+    -   `body.metadata` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** The item's metadata (optional, default `{}`)
 
 **Examples**
 
 ```javascript
-curl \
--X POST \
--H "Content-Type: application/json" \
--d '{"id":"405270","instructions":"Fix this item","pin":[0,0]}' \
-https://host/v1/projects/00000000-0000-0000-0000-000000000000/items
+curl -X POST -H "Content-Type: application/json" -d '{"id":"405270","instructions":"Fix this item","pin":[0,0]}' https://host/v1/projects/00000000-0000-0000-0000-000000000000/items
 
 {
   status: 'open',
   lockedTill: '2017-10-19T00:00:00.000Z',
-  siblings: [],
   metadata: {},
   id: '405270',
   project_id: '00000000-0000-0000-0000-000000000000',
@@ -431,20 +426,22 @@ curl -X PUT -H "Content-Type: application/json" -d '{"metadata":{"key":"value"}}
 }
 ```
 
-### delete-item-comment
+### delete-comment
 
-Delete a comment - make a DELETE request
+Delete a comment
 
 **Parameters**
 
 -   `params` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** The request URL parameters
     -   `params.project` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The project ID
     -   `params.item` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The item ID
+    -   `params.comment` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The comment ID
 
 **Examples**
 
 ```javascript
 curl -X DELETE -H https://host/v1/projects/00000000-0000-0000-0000-000000000000/items/1234/comments/abcd-1234-abcd-1234
+
 {
   "id": "1640ffd8-1d60-44a0-875c-d61231dbbdd5",
   "createdBy": "userone",
@@ -551,7 +548,7 @@ curl -X POST -H "Content-Type: application/json" -d '{"tag":"22222222-2222-2222-
 ]
 ```
 
-### get-project-item
+### get-item
 
 Get an item for a project.
 
@@ -569,7 +566,6 @@ curl https://host/v1/projects/00000000-0000-0000-0000-000000000000/items/405270
 {
   status: 'open',
   lockedTill: '2017-10-19T00:00:00.000Z',
-  siblings: [],
   metadata: {},
   id: '405270',
   project_id: '00000000-0000-0000-0000-000000000000',
@@ -640,20 +636,16 @@ Update a project item.
     -   `body.status` **(`"open"` \| `"fixed"` \| `"noterror"`)?** The item's status
     -   `body.featureCollection` **FeatureCollection?** The item's featureCollection context
     -   `body.instructions` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** Instructions on how to work on the item
+    -   `body.metadata` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** The item's metadata
 
 **Examples**
 
 ```javascript
-curl \
--X PUT \
--H "Content-Type: application/json" \
--d '{"instructions":"Different instructions for fixing the item"}' \
-https://host/v1/projects/00000000-0000-0000-0000-000000000000/items/405270
+curl -X PUT -H "Content-Type: application/json" -d '{"instructions":"Different instructions for fixing the item"}' https://host/v1/projects/00000000-0000-0000-0000-000000000000/items/405270
 
 {
   status: 'open',
   lockedTill: '2017-10-19T00:00:00.000Z',
-  siblings: [],
   metadata: {},
   id: '405270',
   project_id: '00000000-0000-0000-0000-000000000000',
@@ -675,7 +667,7 @@ https://host/v1/projects/00000000-0000-0000-0000-000000000000/items/405270
 
 ### putItemWrapper
 
-handle all the logic and some validation for item creation and updating
+Handle all the logic and some validation for item creation and updating
 
 **Parameters**
 

--- a/routes/comment.js
+++ b/routes/comment.js
@@ -11,44 +11,44 @@ module.exports = {
 
 /**
  * Get a list of comments for an item
- * @name get-item-comments
+ * @name get-comments
  * @param {Object} params - The request URL parameters
  * @param {string} params.project - The project ID
  * @param {string} params.item - The item ID
  * @example
  * curl https://host/v1/projects/:project/items/:item/comments
- * 
+ *
  * [
- * {
- *   "id": "e67c585d-d93f-4ea6-a59f-87b8b54e6efd",
- *   "createdBy": "usertwo",
- *   "body": "first",
- *   "coordinates": {
- *     "type": "Point",
- *     "coordinates": [
- *       0,
- *       0
- *     ]
+ *   {
+ *     "id": "e67c585d-d93f-4ea6-a59f-87b8b54e6efd",
+ *     "createdBy": "usertwo",
+ *     "body": "first",
+ *     "coordinates": {
+ *       "type": "Point",
+ *       "coordinates": [
+ *         0,
+ *         0
+ *       ]
+ *     },
+ *     "metadata": {},
+ *     "createdAt": "2017-10-20T20:39:06.580Z",
+ *     "updatedAt": "2017-10-20T20:39:06.580Z"
  *   },
- *   "metadata": {},
- *   "createdAt": "2017-10-20T20:39:06.580Z",
- *   "updatedAt": "2017-10-20T20:39:06.580Z"
- * },
- * {
- *   "id": "3a47cd22-1761-4582-8cc6-32da1c0bd970",
- *   "createdBy": "userone",
- *   "body": "second",
- *   "coordinates": {
- *     "type": "Point",
- *     "coordinates": [
- *       0,
- *       0
- *     ]
- *   },
- *   "metadata": {},
- *   "createdAt": "2017-10-20T20:39:06.581Z",
- *   "updatedAt": "2017-10-20T20:39:06.581Z"
- * }
+ *   {
+ *     "id": "3a47cd22-1761-4582-8cc6-32da1c0bd970",
+ *     "createdBy": "userone",
+ *     "body": "second",
+ *     "coordinates": {
+ *       "type": "Point",
+ *       "coordinates": [
+ *         0,
+ *         0
+ *       ]
+ *     },
+ *     "metadata": {},
+ *     "createdAt": "2017-10-20T20:39:06.581Z",
+ *     "updatedAt": "2017-10-20T20:39:06.581Z"
+ *   }
  * ]
  */
 function getItemComments(req, res, next) {
@@ -74,33 +74,31 @@ function getItemComments(req, res, next) {
 
 /**
  * Create a comment
- * @name create-item-comment
+ * @name create-comment
  * @param {Object} params - The request URL parameters
  * @param {string} params.project - The project ID
  * @param {string} params.item - The item ID
  * @param {Object} body - The request body
- * @param {string} body.body - Body of the comment (required)
- * @param {Array} body.pin - coordinates of pin
+ * @param {string} body.body - Comment body
+ * @param {Array<number>} [body.pin=null] - Comment coordinates
+ * @param {Object} [body.metadata={}] - Comment metadata
  * @example
- * curl \
- * -X POST \
- * -H "Content-Type: application/json" \
- * -d '{"body":"i like this item","pin":[0,0]}' \
- * https://host/v1/projects/00000000-0000-0000-0000-000000000000/items/77
+ * curl -X POST -H "Content-Type: application/json" -d '{"body":"i like this item","pin":[0,0]}' https://host/v1/projects/00000000-0000-0000-0000-000000000000/items/77
+ *
  * {
- * "id": "d0280f1f-c5cc-448d-9b88-5cf9e52f8e18",
- * "createdBy": "userone",
- * "body": "i like this item",
- * "pin": {
- *   "type": "Point",
- *   "coordinates": [
- *     0,
- *     0
- *   ]
- * },
- * "metadata": {},
- * "createdAt": "2017-10-23T17:18:01.801Z",
- * "updatedAt": "2017-10-23T17:18:01.801Z"
+ *   "id": "d0280f1f-c5cc-448d-9b88-5cf9e52f8e18",
+ *   "createdBy": "userone",
+ *   "body": "i like this item",
+ *   "pin": {
+ *     "type": "Point",
+ *     "coordinates": [
+ *       0,
+ *       0
+ *     ]
+ *   },
+ *   "metadata": {},
+ *   "createdAt": "2017-10-23T17:18:01.801Z",
+ *   "updatedAt": "2017-10-23T17:18:01.801Z"
  * }
  */
 function createItemComment(req, res, next) {
@@ -162,14 +160,15 @@ function createItemComment(req, res, next) {
 }
 
 /**
- * Delete a comment - make a DELETE request
- * @name delete-item-comment
+ * Delete a comment
+ * @name delete-comment
  * @param {Object} params - The request URL parameters
  * @param {string} params.project - The project ID
  * @param {string} params.item - The item ID
- * @pram {string} params.comment - The comment ID
+ * @param {string} params.comment - The comment ID
  * @example
  * curl -X DELETE -H https://host/v1/projects/00000000-0000-0000-0000-000000000000/items/1234/comments/abcd-1234-abcd-1234
+ *
  * {
  *   "id": "1640ffd8-1d60-44a0-875c-d61231dbbdd5",
  *   "createdBy": "userone",

--- a/routes/item.js
+++ b/routes/item.js
@@ -19,15 +19,15 @@ module.exports = {
 
 /**
  * Get a paginated list of items for a project.
- * @name get-project-items
+ * @name get-items
  * @param {Object} params - The request URL parameters
  * @param {string} params.project - The project ID
- * @param {Object} query - The request URL query parameters
+ * @param {Object} [query] - The request URL query parameters
  * @param {('locked'|'unlocked')} [query.lock='locked'] - The item's lock status, must be 'locked' or 'unlocked'
  * @param {string} [query.page=0] - The pagination start page
  * @param {string} [query.page_size=100] - The page size
- * @param {string} query.bbox - BBOX to query by, string in W,S,E,N format - eg. -1,-1,0,0
- * @param {string} query.status - Status to filter items by
+ * @param {string} [query.bbox] - BBOX to query by, string in W,S,E,N format (e.g. -1,-1,0,0)
+ * @param {string} [query.status] - Status to filter items by
  * @example
  * curl https://host/v1/projects/:project/items
  *
@@ -35,7 +35,6 @@ module.exports = {
  *   {
  *     status: 'open',
  *     lockedTill: '2017-10-19T00:00:00.000Z',
- *     siblings: [],
  *     metadata: {},
  *     id: '405270',
  *     project_id: '00000000-0000-0000-0000-000000000000',
@@ -129,17 +128,13 @@ function getItems(req, res, next) {
  * @param {('unlocked'|'locked')} [body.lock] - The item's lock status
  * @param {('open'|'fixed'|'noterror')} [body.status] - The item's status
  * @param {FeatureCollection} [body.featureCollection] - The item's featureCollection context
+ * @param {Object} [body.metadata={}] - The item's metadata
  * @example
- * curl \
- * -X POST \
- * -H "Content-Type: application/json" \
- * -d '{"id":"405270","instructions":"Fix this item","pin":[0,0]}' \
- * https://host/v1/projects/00000000-0000-0000-0000-000000000000/items
+ * curl -X POST -H "Content-Type: application/json" -d '{"id":"405270","instructions":"Fix this item","pin":[0,0]}' https://host/v1/projects/00000000-0000-0000-0000-000000000000/items
  *
  * {
  *   status: 'open',
  *   lockedTill: '2017-10-19T00:00:00.000Z',
- *   siblings: [],
  *   metadata: {},
  *   id: '405270',
  *   project_id: '00000000-0000-0000-0000-000000000000',
@@ -165,7 +160,8 @@ function createItem(req, res, next) {
     'pin',
     'status',
     'featureCollection',
-    'instructions'
+    'instructions',
+    'metadata'
   ];
   const requiredBodyAttr = ['id', 'instructions', 'pin'];
   const validationError = validateBody(
@@ -278,7 +274,7 @@ function createItem(req, res, next) {
 
 /**
  * Get an item for a project.
- * @name get-project-item
+ * @name get-item
  * @param {Object} params - The request URL parameters
  * @param {string} params.project - The project ID
  * @param {string} params.item - The item ID
@@ -288,7 +284,6 @@ function createItem(req, res, next) {
  * {
  *   status: 'open',
  *   lockedTill: '2017-10-19T00:00:00.000Z',
- *   siblings: [],
  *   metadata: {},
  *   id: '405270',
  *   project_id: '00000000-0000-0000-0000-000000000000',
@@ -333,17 +328,13 @@ function getItem(req, res, next) {
  * @param {('open'|'fixed'|'noterror')} [body.status] - The item's status
  * @param {FeatureCollection} [body.featureCollection] - The item's featureCollection context
  * @param {string} [body.instructions] - Instructions on how to work on the item
+ * @param {Object} [body.metadata] - The item's metadata
  * @example
- * curl \
- * -X PUT \
- * -H "Content-Type: application/json" \
- * -d '{"instructions":"Different instructions for fixing the item"}' \
- * https://host/v1/projects/00000000-0000-0000-0000-000000000000/items/405270
+ * curl -X PUT -H "Content-Type: application/json" -d '{"instructions":"Different instructions for fixing the item"}' https://host/v1/projects/00000000-0000-0000-0000-000000000000/items/405270
  *
  * {
  *   status: 'open',
  *   lockedTill: '2017-10-19T00:00:00.000Z',
- *   siblings: [],
  *   metadata: {},
  *   id: '405270',
  *   project_id: '00000000-0000-0000-0000-000000000000',
@@ -368,7 +359,8 @@ function updateItem(req, res, next) {
     'pin',
     'status',
     'featureCollection',
-    'instructions'
+    'instructions',
+    'metadata'
   ];
   const validationError = validateBody(req.body, validBodyAttrs);
   if (validationError)
@@ -463,7 +455,7 @@ function updateItem(req, res, next) {
 }
 
 /**
- * handle all the logic and some validation for item creation and updating
+ * Handle all the logic and some validation for item creation and updating
  * @param {Object} opts - the opts for the action
  * @param {String} opts.project - the id of the project the item belongs to
  * @param {String} opts.item - the id of the item itself

--- a/routes/project.js
+++ b/routes/project.js
@@ -99,10 +99,12 @@ function getProject(req, res, next) {
 
 /**
  * Update a project.
- * @name updateProject
+ * @name update-project
  * @param {Object} params - The request URL parameters
  * @param {string} params.project - The project ID
  * @param {Object} body - The request body
+ * @param {string} [body.name] - The project name
+ * @param {Object} [body.metadata] - The project metadata
  * @example
  * curl -X PUT -H "Content-Type: application/json" -d '{"metadata":{"key":"value"}}' https://host/v1/projects/00000000-0000-0000-0000-000000000000
  *


### PR DESCRIPTION
This PR:

- Allow user to always pass a `metadata` property on POST and PUT requests (:warning: I don't think we're handling this appropriately for items yet but I think that's okay for now)
- Updates documentation