### PR TITLE
catch invalid project UUIDs early to avoid 500 errors

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -17,7 +17,7 @@ const tag = require('../routes/tag');
 const auth = require('../routes/auth');
 const user = require('../routes/user');
 const server = (module.exports = express());
-
+const validateParams = require('./validate-params');
 const middleware = require('./middleware');
 const db = require('../database/index');
 
@@ -27,12 +27,15 @@ const sessionStore = new SequelizeStore({
 });
 
 server.use(cors());
+
 server.use(
   bodyParser.json({
     limit: '50mb'
   })
 );
+
 server.use(middleware);
+
 server.use(
   session({
     store: sessionStore,
@@ -48,26 +51,75 @@ server.get('/', status.getStatus);
 
 server.get('/:version/user', user.getUser);
 
-server.get('/:version/projects', project.getProjects);
-server.post('/:version/projects', project.createProject);
-server.get('/:version/projects/:project', project.getProject);
-server.put('/:version/projects/:project', project.updateProject);
-server.get('/:version/projects/:project/stats', project.getProjectStats);
+server.get('/:version/projects', validateParams, project.getProjects);
+server.post('/:version/projects', validateParams, project.createProject);
+server.get('/:version/projects/:project', validateParams, project.getProject);
+server.put(
+  '/:version/projects/:project',
+  validateParams,
+  project.updateProject
+);
+server.get(
+  '/:version/projects/:project/stats',
+  validateParams,
+  project.getProjectStats
+);
 
-server.get('/:version/projects/:project/items', item.getItems);
-server.post('/:version/projects/:project/items', item.createItem);
-server.get('/:version/projects/:project/items/:item', item.getItem);
-server.put('/:version/projects/:project/items/:item', item.updateItem);
+server.get('/:version/projects/:project/items', validateParams, item.getItems);
+server.post(
+  '/:version/projects/:project/items',
+  validateParams,
+  item.createItem
+);
+server.get(
+  '/:version/projects/:project/items/:item',
+  validateParams,
+  item.getItem
+);
+server.put(
+  '/:version/projects/:project/items/:item',
+  validateParams,
+  item.updateItem
+);
 
-server.get('/:version/projects/:project/tags', tag.getProjectTags);
-server.post('/:version/projects/:project/tags', tag.createProjectTag);
-server.get('/:version/projects/:project/tags/:tag', tag.getProjectTag);
-server.put('/:version/projects/:project/tags/:tag', tag.updateProjectTag);
-server.delete('/:version/projects/:project/tags/:tag', tag.deleteProjectTag);
-server.get('/:version/projects/:project/items/:item/tags', tag.getItemTags);
-server.post('/:version/projects/:project/items/:item/tags', tag.createItemTag);
+server.get(
+  '/:version/projects/:project/tags',
+  validateParams,
+  tag.getProjectTags
+);
+server.post(
+  '/:version/projects/:project/tags',
+  validateParams,
+  tag.createProjectTag
+);
+server.get(
+  '/:version/projects/:project/tags/:tag',
+  validateParams,
+  tag.getProjectTag
+);
+server.put(
+  '/:version/projects/:project/tags/:tag',
+  validateParams,
+  tag.updateProjectTag
+);
+server.delete(
+  '/:version/projects/:project/tags/:tag',
+  validateParams,
+  tag.deleteProjectTag
+);
+server.get(
+  '/:version/projects/:project/items/:item/tags',
+  validateParams,
+  tag.getItemTags
+);
+server.post(
+  '/:version/projects/:project/items/:item/tags',
+  validateParams,
+  tag.createItemTag
+);
 server.delete(
   '/:version/projects/:project/items/:item/tags/:tag',
+  validateParams,
   tag.deleteItemTag
 );
 
@@ -76,14 +128,17 @@ server.get('/:version/auth/openstreetmap/callback', auth.handleOSMCallback);
 
 server.get(
   '/:version/projects/:project/items/:item/comments',
+  validateParams,
   comment.getItemComments
 );
 server.post(
   '/:version/projects/:project/items/:item/comments',
+  validateParams,
   comment.createItemComment
 );
 server.delete(
   '/:version/projects/:project/items/:item/comments/:comment',
+  validateParams,
   comment.deleteItemComment
 );
 

--- a/lib/validate-params.js
+++ b/lib/validate-params.js
@@ -1,0 +1,11 @@
+const validator = require('validator');
+const ErrorHTTP = require('mapbox-error').ErrorHTTP;
+
+module.exports = function(req, res, next) {
+  if (req.params.project) {
+    if (!validator.isUUID(req.params.project)) {
+      return next(new ErrorHTTP('Project ID must be a valid UUID', 400));
+    }
+  }
+  return next();
+};

--- a/test/project.test.js
+++ b/test/project.test.js
@@ -139,6 +139,21 @@ test(
 );
 
 test(
+  'GET /:version/projects/:project - get project with invalid UUID',
+  [],
+  (assert, token) => {
+    assert.app
+      .get('/v1/projects/invalid-uuid')
+      .set('authorization', token)
+      .expect(400, (err, res) => {
+        assert.ifError(err);
+        assert.equal(res.body.message, 'Project ID must be a valid UUID');
+        assert.end();
+      });
+  }
+);
+
+test(
   'CREATE /:version/projects - invalid body attributes',
   [
     {


### PR DESCRIPTION
This fixes #215 but not sure if there is a better way to do this

cc @emilymdubois 