### PR TITLE
add filter for from and to dates in items list endpoint

### DIFF
--- a/API.md
+++ b/API.md
@@ -162,6 +162,8 @@ Get a paginated list of items for a project.
     -   `query.bbox` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** BBOX to query by, string in W,S,E,N format (e.g. -1,-1,0,0)
     -   `query.status` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** Status to filter items by
     -   `query.tags` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** Comma-separated list of tag ids
+    -   `query.from` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** From date to filter by (must be a valid ISO 8601 date string)
+    -   `query.to` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** To date to filter by (must be a valid ISO 8601 date string)
 
 **Examples**
 
@@ -360,6 +362,62 @@ curl -X PUT -H "Content-Type: application/json" -d '{"metadata":{"key":"value"}}
 }
 ```
 
+### delete-comment
+
+Delete a comment
+
+**Parameters**
+
+-   `params` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** The request URL parameters
+    -   `params.project` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The project ID
+    -   `params.item` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The item ID
+    -   `params.comment` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The comment ID
+
+**Examples**
+
+```javascript
+curl -X DELETE -H https://host/v1/projects/00000000-0000-0000-0000-000000000000/items/1234/comments/abcd-1234-abcd-1234
+
+{
+  "id": "1640ffd8-1d60-44a0-875c-d61231dbbdd5",
+  "createdBy": "userone",
+  "body": "second",
+  "pin": {
+    "type": "Point",
+    "coordinates": [
+      0,
+      0
+    ]
+  },
+  "metadata": {},
+  "createdAt": "2017-10-23T17:13:25.585Z",
+  "updatedAt": "2017-10-23T17:13:25.585Z"
+}
+```
+
+### get-project
+
+Get a project.
+
+**Parameters**
+
+-   `params` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** The request URL parameters
+    -   `params.project` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The project ID
+
+**Examples**
+
+```javascript
+curl https://host/v1/projects/00000000-0000-0000-0000-000000000000
+
+{
+  id: '00000000-0000-0000-0000-000000000000',
+  name: 'My Project',
+  metadata: {},
+  createdAt: '2017-10-18T00:00:00.000Z',
+  updatedAt: '2017-10-18T00:00:00.000Z'
+}
+```
+
 ### create-item
 
 Create an item in a project.
@@ -401,62 +459,6 @@ curl -X POST -H "Content-Type: application/json" -d '{"id":"405270","instruction
   updatedAt: '2017-10-19T00:00:00.000Z',
   createdAt: '2017-10-19T00:00:00.000Z',
   lockedBy: null
-}
-```
-
-### get-project
-
-Get a project.
-
-**Parameters**
-
--   `params` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** The request URL parameters
-    -   `params.project` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The project ID
-
-**Examples**
-
-```javascript
-curl https://host/v1/projects/00000000-0000-0000-0000-000000000000
-
-{
-  id: '00000000-0000-0000-0000-000000000000',
-  name: 'My Project',
-  metadata: {},
-  createdAt: '2017-10-18T00:00:00.000Z',
-  updatedAt: '2017-10-18T00:00:00.000Z'
-}
-```
-
-### delete-comment
-
-Delete a comment
-
-**Parameters**
-
--   `params` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** The request URL parameters
-    -   `params.project` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The project ID
-    -   `params.item` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The item ID
-    -   `params.comment` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The comment ID
-
-**Examples**
-
-```javascript
-curl -X DELETE -H https://host/v1/projects/00000000-0000-0000-0000-000000000000/items/1234/comments/abcd-1234-abcd-1234
-
-{
-  "id": "1640ffd8-1d60-44a0-875c-d61231dbbdd5",
-  "createdBy": "userone",
-  "body": "second",
-  "pin": {
-    "type": "Point",
-    "coordinates": [
-      0,
-      0
-    ]
-  },
-  "metadata": {},
-  "createdAt": "2017-10-23T17:13:25.585Z",
-  "updatedAt": "2017-10-23T17:13:25.585Z"
 }
 ```
 
@@ -577,6 +579,42 @@ curl -X POST -H "Content-Type: application/json" -d '{"tag":"22222222-2222-2222-
 ]
 ```
 
+### delete-item-tag
+
+Remove a tag from an item.
+
+**Parameters**
+
+-   `params` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** The request URL parameters
+    -   `params.version` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The API version
+    -   `params.project` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The project ID
+    -   `params.item` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The item ID
+    -   `params.tag` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The tag ID
+
+**Examples**
+
+```javascript
+curl -X DELETE https://host/v1/projects/00000000-0000-0000-0000-000000000000/items/111111/tags/22222222-2222-2222-2222-222222222222
+
+{
+  id: '111111',
+  project_id: '00000000-0000-0000-0000-000000000000',
+  pin: { type: 'Point', coordinates: [77, 77] },
+  instructions: 'Fix this item',
+  createdBy: 'user',
+  featureCollection: { type: 'FeatureCollection', features: [] },
+  status: 'open',
+  lockedBy: null,
+  metadata: {},
+  sort: 0,
+  createdAt: '2017-10-20T00:00:00.000Z',
+  updatedAt: '2017-10-20T00:00:00.000Z',
+  lockedTill: '2017-10-20T00:00:00.000Z'
+}
+```
+
+Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)>** tags - An array of remaining tags on the item
+
 ### get-item
 
 Get an item for a project.
@@ -613,42 +651,6 @@ curl https://host/v1/projects/00000000-0000-0000-0000-000000000000/items/405270
   lockedBy: null
 }
 ```
-
-### delete-item-tag
-
-Remove a tag from an item.
-
-**Parameters**
-
--   `params` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** The request URL parameters
-    -   `params.version` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The API version
-    -   `params.project` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The project ID
-    -   `params.item` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The item ID
-    -   `params.tag` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The tag ID
-
-**Examples**
-
-```javascript
-curl -X DELETE https://host/v1/projects/00000000-0000-0000-0000-000000000000/items/111111/tags/22222222-2222-2222-2222-222222222222
-
-{
-  id: '111111',
-  project_id: '00000000-0000-0000-0000-000000000000',
-  pin: { type: 'Point', coordinates: [77, 77] },
-  instructions: 'Fix this item',
-  createdBy: 'user',
-  featureCollection: { type: 'FeatureCollection', features: [] },
-  status: 'open',
-  lockedBy: null,
-  metadata: {},
-  sort: 0,
-  createdAt: '2017-10-20T00:00:00.000Z',
-  updatedAt: '2017-10-20T00:00:00.000Z',
-  lockedTill: '2017-10-20T00:00:00.000Z'
-}
-```
-
-Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)>** tags - An array of remaining tags on the item
 
 ### update-item
 

--- a/test/item.test.js
+++ b/test/item.test.js
@@ -141,13 +141,15 @@ const listItemsFixture = [
         id: '60',
         pin: [30, 30],
         lockedBy: 'userone',
-        lockedTill: new Date(Date.now() - 1000 * 15 * 60)
+        lockedTill: new Date(Date.now() - 1000 * 15 * 60),
+        createdAt: '2017-10-03T17:49:25.928Z'
       },
       {
         id: '62',
         pin: [30, 30],
         lockedBy: 'usertwo',
-        lockedTill: new Date(Date.now() + 2 * 1000 * 15 * 60)
+        lockedTill: new Date(Date.now() + 2 * 1000 * 15 * 60),
+        createdAt: '2017-10-04T17:49:25.928Z'
       },
       {
         id: '63',
@@ -482,6 +484,47 @@ test(
       .expect(200, (err, res) => {
         assert.ifError(err, 'should not error');
         assert.equal(res.body.length, 1, 'should have 1 noterror item');
+        assert.end();
+      });
+  }
+);
+
+test(
+  'GET /:version/projects/:id/items?from=<date>&to=<date> - filter items by date',
+  listItemsFixture,
+  (assert, token) => {
+    assert.app
+      .get(
+        '/v1/projects/44444444-4444-4444-4444-444444444444/items?from=2017-10-01&to=2017-10-10'
+      )
+      .set('authorization', token)
+      .expect(200, (err, res) => {
+        assert.ifError(err, 'date filtering should not error');
+        assert.equal(
+          res.body.length,
+          2,
+          'should have 2 items within date filter'
+        );
+        assert.end();
+      });
+  }
+);
+
+test(
+  'GET /:version/projects/:id/items?from=<date>&to=<date> - filter items by invalid date',
+  listItemsFixture,
+  (assert, token) => {
+    assert.app
+      .get(
+        '/v1/projects/44444444-4444-4444-4444-444444444444/items?from=foobar'
+      )
+      .set('authorization', token)
+      .expect(400, (err, res) => {
+        assert.ifError(err, 'invalid date filter does not error');
+        assert.equal(
+          res.body.message,
+          'from parameter must be a valid ISO 8601 date string'
+        );
         assert.end();
       });
   }

--- a/test/lib/test.js
+++ b/test/lib/test.js
@@ -113,7 +113,8 @@ function setup(fixture) {
               lockedBy: item.lockedBy || null,
               lockedTill: item.lockedTill,
               createdBy: item.createdBy || 'userone',
-              instructions: item.instructions || 'created via the tests'
+              instructions: item.instructions || 'created via the tests',
+              createdAt: item.createdAt || new Date()
             });
           });
           return Promise.all(promise);


### PR DESCRIPTION
Adds to query parameters to the `get-project-items` endpoint called `from` and `to`.

cc @emilymdubois @samanpwbb - lemme know if the naming of parameters, etc works - it currently uses the `createdAt` field in the database, so this would be when the item was first created in the backend.