### PR TITLE
Add shared secret config to enable a trusted client to wrap the JWT auth token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,4 @@ APP_SECRET='sasdfsdfsdfdsf' #can be any random string, hard to guess
 FRONTEND_URL='http://localhost:8000'
 LOG_STREAM_NAME="my-logging-firehose-name"
 ENABLE_KINESIS_LOGGING=true
+JWT_TRUSTED_CLIENT_SECRET=s3cret

--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ PG_PORT=database-port
 
 The sequelize CLI is configured from these environment variables in the file `sequelize-config.js`.
 
+**Trusted Client**
+
+If you want to restrict your deployment to users of a trusted frontend client app, you can wrap the
+JWT authentication token in another JWT token that is signed with a secret you share between
+this backend and your trusted client app.
+
+You will need to add that shared secret to the environment:
+
+```
+JWT_TRUSTED_CLIENT_SECRET=your super-duper s3cret
+```
+
 **Running tests**
 
 `npm test`

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -14,22 +14,14 @@ module.exports = function(req, res, next) {
 
   const token = getToken(req);
   const payload = token ? getPayload(token) : null;
-  let isTrustedUser;
 
   if (payload && payload.id) {
     req.user = payload;
-    if (process.env.trustedUsers) {
-      const trustedUsers = JSON.parse(process.env.trustedUsers);
-      isTrustedUser = trustedUsers.indexOf(payload.id) !== -1;
-    } else {
-      isTrustedUser = true; // if no env var, all OSM users are trusted
-    }
   } else {
     req.user = null;
-    isTrustedUser = false;
   }
 
-  if (!isTrustedUser) {
+  if (!req.user) {
     return next(new ErrorHTTP('Token Authentication Failed', 401));
   } else {
     return next();
@@ -60,6 +52,12 @@ function getToken(request) {
 function getPayload(token) {
   let decoded;
   try {
+    // JWT_TRUSTED_CLIENT_SECRET can be used to wrap the JWT in another JWT token
+    // This is useful for running your own instance and restricting access to your
+    // project data to users of your trusted frontend client app.
+    if (process.env.JWT_TRUSTED_CLIENT_SECRET) {
+      token = jwt.decode(token, process.env.JWT_TRUSTED_CLIENT_SECRET);
+    }
     decoded = jwt.decode(token, process.env.APP_SECRET);
   } catch (err) {
     decoded = undefined;

--- a/test/lib/test.js
+++ b/test/lib/test.js
@@ -1,7 +1,7 @@
 const tape = require('tape');
 process.env.PG_DATABASE = 'tofix_test';
 process.env.APP_SECRET = 'fakesecret';
-process.env.trustedUsers = '[123]';
+process.env.JWT_TRUSTED_CLIENT_SECRET = 's3cret';
 const server = require('../../lib/server');
 const supertest = require('supertest');
 const app = supertest(server);
@@ -14,7 +14,7 @@ const _ = require('lodash');
 
 var pendingTests = 0;
 
-const testToken = jwt.encode(
+const originalToken = jwt.encode(
   {
     id: 123,
     username: 'test-user',
@@ -22,6 +22,7 @@ const testToken = jwt.encode(
   },
   process.env.APP_SECRET
 );
+const testToken = jwt.encode(originalToken, process.env.JWT_TRUSTED_CLIENT_SECRET);
 
 module.exports = function(testName, fixture, cb) {
   pendingTests++;


### PR DESCRIPTION
By allowing a trusted client to use a shared secret to wrap the jwt token, the backend can ensure that the user is using the trusted client.